### PR TITLE
feat: add bilingual Next.js NGO homepage

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,14 @@
+node_modules
+.next
+out
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,0 +1,58 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  @apply bg-white text-darkBlue font-sans antialiased transition-colors duration-300 ease-linear;
+}
+
+body.dark {
+  @apply bg-[#060b1a] text-white;
+}
+
+.hero-overlay {
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.18), transparent 60%),
+    radial-gradient(circle at 80% 0%, rgba(0, 187, 255, 0.35), transparent 65%),
+    radial-gradient(circle at 50% 80%, rgba(0, 187, 255, 0.2), transparent 70%);
+}
+
+.shadow-card {
+  box-shadow: 0 25px 60px -20px rgba(11, 30, 63, 0.2);
+}
+
+.section-heading {
+  @apply text-3xl font-semibold tracking-tight text-darkBlue dark:text-white;
+}
+
+.section-subheading {
+  @apply mt-2 max-w-2xl text-base text-darkBlue/70 dark:text-gray-300;
+}
+
+.card-surface {
+  @apply rounded-3xl border border-white/60 bg-white/80 p-8 shadow-card backdrop-blur dark:border-white/10 dark:bg-white/5;
+}
+
+.timeline-line {
+  background: linear-gradient(90deg, rgba(0, 187, 255, 0.15) 0%, rgba(0, 187, 255, 0.85) 100%);
+}
+
+.timeline-dot {
+  @apply size-6 rounded-full border-4 border-white bg-primary shadow-lg dark:border-darkBlue;
+}
+
+.counter-value {
+  @apply text-4xl font-bold text-darkBlue dark:text-primary;
+}
+
+.parallax-cta {
+  background: linear-gradient(135deg, rgba(0, 187, 255, 0.92) 0%, rgba(11, 30, 63, 0.92) 100%);
+  box-shadow: 0 20px 60px rgba(0, 187, 255, 0.25);
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { Inter, Tajawal } from "next/font/google";
+import "./globals.css";
+import { Providers } from "../components/providers";
+import { cn } from "../lib/utils";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
+const tajawal = Tajawal({ subsets: ["arabic"], variable: "--font-kufi" });
+
+export const metadata: Metadata = {
+  title: "Shifaa | Humanitarian Relief & Empowerment",
+  description:
+    "Shifaa is a humanitarian NGO providing emergency relief, healthcare, education, and protection programs for displaced families across the region."
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className={cn(inter.variable, tajawal.variable, "min-h-screen bg-white text-darkBlue antialiased dark:bg-[#060b1a]")}>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,0 +1,27 @@
+import { Navbar } from "../components/navbar";
+import { Hero } from "../components/hero";
+import { ProblemSection } from "../components/problem-section";
+import { PlanSection } from "../components/plan-section";
+import { SuccessStories } from "../components/success-stories";
+import { ImpactStats } from "../components/impact-stats";
+import { PartnersSection } from "../components/partners-section";
+import { DonationCta } from "../components/donation-cta";
+import { SiteFooter } from "../components/site-footer";
+
+export default function HomePage() {
+  return (
+    <div className="bg-white text-darkBlue dark:bg-[#060b1a] dark:text-white">
+      <Navbar />
+      <main className="space-y-0">
+        <Hero />
+        <ProblemSection />
+        <PlanSection />
+        <SuccessStories />
+        <ImpactStats />
+        <PartnersSection />
+        <DonationCta />
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}

--- a/web/components/donation-cta.tsx
+++ b/web/components/donation-cta.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { motion } from "framer-motion";
+import { useLanguage } from "./language-provider";
+import { Button } from "./ui/button";
+import { gsap } from "../lib/gsap";
+
+export function DonationCta() {
+  const { t, direction } = useLanguage();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const ctx = gsap.context(() => {
+      if (!containerRef.current) return;
+      gsap.fromTo(
+        containerRef.current,
+        { y: 60, opacity: 0 },
+        {
+          y: 0,
+          opacity: 1,
+          duration: 0.8,
+          ease: "power3.out",
+          scrollTrigger: {
+            trigger: containerRef.current,
+            start: "top 80%"
+          }
+        }
+      );
+    }, containerRef);
+
+    return () => ctx.revert();
+  }, []);
+
+  return (
+    <section id="cta" className="py-24" dir={direction}>
+      <div className="mx-auto max-w-5xl px-6">
+        <motion.div
+          ref={containerRef}
+          className="parallax-cta relative overflow-hidden rounded-[2.5rem] px-8 py-14 text-white"
+          initial={{ scale: 0.96, opacity: 0 }}
+          whileInView={{ scale: 1, opacity: 1 }}
+          viewport={{ once: true, amount: 0.3 }}
+          transition={{ duration: 0.8, ease: "easeOut" }}
+        >
+          <div className="relative z-10 flex flex-col gap-6 text-center">
+            <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl">{t.cta.heading}</h2>
+            <p className="mx-auto max-w-2xl text-sm text-white/80 sm:text-base">{t.cta.description}</p>
+            <div className="flex justify-center">
+              <Button
+                href="https://donate.shifaa.org"
+                className="animate-[pulse_2.5s_ease-in-out_infinite] bg-white text-darkBlue shadow-glow"
+                aria-label={t.cta.action}
+              >
+                {t.cta.action}
+              </Button>
+            </div>
+          </div>
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.35),_transparent_55%)]" />
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/web/components/hero.tsx
+++ b/web/components/hero.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import Image from "next/image";
+import { ArrowUpRight, Heart } from "lucide-react";
+import { useEffect, useRef } from "react";
+import { Button } from "./ui/button";
+import { useLanguage } from "./language-provider";
+import { gsap } from "../lib/gsap";
+
+export function Hero() {
+  const { t, direction } = useLanguage();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const statsRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const ctx = gsap.context(() => {
+      const heroTimeline = gsap.timeline({ defaults: { ease: "power3.out" } });
+      heroTimeline
+        .from("[data-animate=hero-preheading]", { y: 30, opacity: 0, duration: 0.6 })
+        .from("[data-animate=hero-heading]", { y: 40, opacity: 0, duration: 0.8 }, "-=0.3")
+        .from("[data-animate=hero-description]", { y: 30, opacity: 0, duration: 0.6 }, "-=0.4")
+        .from("[data-animate=hero-ctas] > *", { y: 30, opacity: 0, stagger: 0.15, duration: 0.5 }, "-=0.4");
+
+      if (statsRef.current) {
+        gsap.fromTo(
+          statsRef.current.children,
+          { y: 30, opacity: 0 },
+          {
+            y: 0,
+            opacity: 1,
+            duration: 0.6,
+            stagger: 0.2,
+            scrollTrigger: {
+              trigger: statsRef.current,
+              start: "top 80%"
+            }
+          }
+        );
+      }
+
+      gsap.to("[data-parallax=hero-bg]", {
+        yPercent: 12,
+        ease: "none",
+        scrollTrigger: {
+          trigger: containerRef.current,
+          start: "top top",
+          scrub: true
+        }
+      });
+    }, containerRef);
+
+    return () => ctx.revert();
+  }, []);
+
+  return (
+    <section
+      id="top"
+      ref={containerRef}
+      className="relative isolate flex min-h-screen items-center overflow-hidden bg-darkBlue text-white"
+      dir={direction}
+    >
+      <Image
+        src="/hero-bg.svg"
+        alt="Abstract humanitarian collage"
+        fill
+        priority
+        data-parallax="hero-bg"
+        className="object-cover opacity-90"
+      />
+      <div className="hero-overlay absolute inset-0" aria-hidden="true" />
+      <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-col gap-12 px-6 py-32 lg:flex-row lg:items-center">
+        <div className="w-full max-w-2xl space-y-6" aria-label="Hero copy">
+          <span
+            data-animate="hero-preheading"
+            className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.3em] text-primary"
+          >
+            <Heart className="h-4 w-4" aria-hidden="true" />
+            {t.hero.preheading}
+          </span>
+          <h1 data-animate="hero-heading" className="text-4xl font-bold leading-tight sm:text-5xl lg:text-6xl">
+            {t.hero.heading}
+          </h1>
+          <p data-animate="hero-description" className="max-w-xl text-base text-white/80 lg:text-lg">
+            {t.hero.description}
+          </p>
+          <div data-animate="hero-ctas" className="flex flex-wrap items-center gap-4">
+            <Button href="#cta" className="shadow-glow">
+              {t.hero.primaryCta}
+            </Button>
+            <Button
+              href="#partners"
+              variant="outline"
+              className="border-white/40 text-white hover:bg-white/10"
+            >
+              <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+              <span>{t.hero.secondaryCta}</span>
+            </Button>
+          </div>
+          <p className="text-sm text-white/70">{t.hero.trustNote}</p>
+        </div>
+        <div className="w-full max-w-md space-y-6 rounded-3xl bg-white/10 p-8 backdrop-blur-lg">
+          <h2 className="text-lg font-semibold text-white">{t.problem.heading}</h2>
+          <p className="text-sm text-white/70">{t.problem.description}</p>
+          <div ref={statsRef} className="grid grid-cols-1 gap-6 sm:grid-cols-3">
+            {t.impact.stats.map((stat) => (
+              <div key={stat.label} className="rounded-2xl bg-white/10 p-4 text-center">
+                <p className="text-3xl font-bold text-white" aria-live="polite">
+                  {new Intl.NumberFormat(direction === "rtl" ? "ar" : "en", {
+                    notation: "compact",
+                    maximumFractionDigits: 1
+                  }).format(stat.value)}
+                  {stat.suffix || ""}
+                </p>
+                <p className="text-xs text-white/70">{stat.label}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/components/impact-stats.tsx
+++ b/web/components/impact-stats.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useLanguage } from "./language-provider";
+import { gsap } from "../lib/gsap";
+
+export function ImpactStats() {
+  const { t, direction } = useLanguage();
+  const countersRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const ctx = gsap.context(() => {
+      if (!countersRef.current) return;
+      const targets = Array.from(countersRef.current.querySelectorAll<HTMLElement>("[data-counter]"));
+      targets.forEach((target) => {
+        const endValue = Number(target.dataset.counter);
+        const counter = { value: 0 };
+        target.textContent = "0";
+        gsap.to(counter, {
+          value: endValue,
+          duration: 2,
+          ease: "power3.out",
+          scrollTrigger: {
+            trigger: target,
+            start: "top 85%"
+          },
+          onUpdate: () => {
+            const formatted = new Intl.NumberFormat(direction === "rtl" ? "ar" : "en").format(Math.round(counter.value));
+            target.textContent = formatted;
+          }
+        });
+      });
+    }, countersRef);
+
+    return () => ctx.revert();
+  }, [direction]);
+
+  return (
+    <section id="impact" className="bg-lightGray/60 py-24 dark:bg-[#0b1328]" dir={direction}>
+      <div className="mx-auto flex max-w-6xl flex-col gap-12 px-6">
+        <div className="max-w-3xl space-y-4">
+          <h2 className="section-heading">{t.impact.heading}</h2>
+          <p className="section-subheading">{t.impact.description}</p>
+        </div>
+        <div ref={countersRef} className="grid grid-cols-1 gap-8 md:grid-cols-3">
+          {t.impact.stats.map((stat) => (
+            <div
+              key={stat.label}
+              className="card-surface flex flex-col items-center gap-3 text-center"
+              role="group"
+              aria-label={`${stat.label} ${stat.value}`}
+            >
+              <span className="counter-value" data-counter={stat.value}>
+                {new Intl.NumberFormat(direction === "rtl" ? "ar" : "en").format(stat.value)}
+                {stat.suffix || ""}
+              </span>
+              <span className="text-sm font-medium text-darkBlue/70 dark:text-gray-300">{stat.label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/components/language-provider.tsx
+++ b/web/components/language-provider.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import type { Locale, SiteContent } from "../data/content";
+import { content } from "../data/content";
+
+type LanguageContextValue = {
+  language: Locale;
+  direction: "ltr" | "rtl";
+  t: SiteContent;
+  toggleLanguage: () => void;
+  setLanguage: (locale: Locale) => void;
+};
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+export function LanguageProvider({ children }: { children: React.ReactNode }) {
+  const [language, setLanguage] = useState<Locale>("en");
+
+  const direction = language === "ar" ? "rtl" : "ltr";
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.dir = direction;
+    root.lang = language;
+  }, [direction, language]);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("shifaa-language") as Locale | null;
+    if (stored && (stored === "en" || stored === "ar")) {
+      setLanguage(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem("shifaa-language", language);
+  }, [language]);
+
+  const value = useMemo(
+    () => ({
+      language,
+      direction,
+      t: content[language],
+      toggleLanguage: () => setLanguage((prev) => (prev === "en" ? "ar" : "en")),
+      setLanguage
+    }),
+    [direction, language]
+  );
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+}
+
+export function useLanguage() {
+  const ctx = useContext(LanguageContext);
+  if (!ctx) {
+    throw new Error("useLanguage must be used within a LanguageProvider");
+  }
+  return ctx;
+}

--- a/web/components/language-toggle.tsx
+++ b/web/components/language-toggle.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { Languages } from "lucide-react";
+import { Button } from "./ui/button";
+import { useLanguage } from "./language-provider";
+
+export function LanguageToggle() {
+  const { language, toggleLanguage, t } = useLanguage();
+
+  return (
+    <Button
+      onClick={toggleLanguage}
+      variant="ghost"
+      className="gap-2 rounded-full border border-transparent px-4 py-2 text-xs font-medium uppercase tracking-wider"
+      aria-label={language === "en" ? "Switch to Arabic" : "Switch to English"}
+    >
+      <Languages className="h-4 w-4" aria-hidden="true" />
+      {t.languageName}
+    </Button>
+  );
+}

--- a/web/components/navbar.tsx
+++ b/web/components/navbar.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { motion } from "framer-motion";
+import Link from "next/link";
+import { Button } from "./ui/button";
+import { LanguageToggle } from "./language-toggle";
+import { ThemeToggle } from "./theme-toggle";
+import { useLanguage } from "./language-provider";
+import { useEffect, useState } from "react";
+import { cn } from "../lib/utils";
+
+const MotionHeader = motion.header;
+
+export function Navbar() {
+  const { t, direction } = useLanguage();
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 24);
+    onScroll();
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <MotionHeader
+      initial={{ y: -60, opacity: 0 }}
+      animate={{ y: 0, opacity: 1 }}
+      transition={{ duration: 0.6, ease: "easeOut" }}
+      className={cn(
+        "fixed inset-x-0 top-0 z-50 px-6 py-4 transition-all",
+        scrolled ? "backdrop-blur bg-white/80 shadow-lg dark:bg-[#060b1a]/80" : "bg-transparent"
+      )}
+      dir={direction}
+    >
+      <nav className="mx-auto flex max-w-6xl items-center justify-between gap-6" aria-label="Main navigation">
+        <Link href="#top" className="flex items-center gap-2" aria-label="Shifaa logo">
+          <span className="inline-flex size-10 items-center justify-center rounded-full bg-primary text-darkBlue font-bold">
+            S
+          </span>
+          <span className="text-lg font-semibold tracking-tight">Shifaa</span>
+        </Link>
+        <div className="hidden items-center gap-8 text-sm font-medium lg:flex">
+          {t.nav.links.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="text-darkBlue/80 transition hover:text-darkBlue dark:text-gray-200 dark:hover:text-white"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+        <div className="flex items-center gap-2">
+          <LanguageToggle />
+          <ThemeToggle />
+          <Button className="hidden text-sm lg:inline-flex" href="#cta">
+            {t.nav.donate}
+          </Button>
+        </div>
+      </nav>
+    </MotionHeader>
+  );
+}

--- a/web/components/partners-section.tsx
+++ b/web/components/partners-section.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useRef } from "react";
+import { useLanguage } from "./language-provider";
+import { gsap } from "../lib/gsap";
+
+export function PartnersSection() {
+  const { t, direction } = useLanguage();
+  const gridRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const ctx = gsap.context(() => {
+      if (!gridRef.current) return;
+      gsap.fromTo(
+        gridRef.current.children,
+        { y: 30, opacity: 0 },
+        {
+          y: 0,
+          opacity: 1,
+          duration: 0.5,
+          stagger: 0.1,
+          ease: "power2.out",
+          scrollTrigger: {
+            trigger: gridRef.current,
+            start: "top 80%"
+          }
+        }
+      );
+    }, gridRef);
+
+    return () => ctx.revert();
+  }, []);
+
+  return (
+    <section id="partners" className="bg-white py-24 dark:bg-[#070d1c]" dir={direction}>
+      <div className="mx-auto flex max-w-6xl flex-col gap-12 px-6">
+        <div className="max-w-3xl space-y-4">
+          <h2 className="section-heading">{t.partners.heading}</h2>
+          <p className="section-subheading">{t.partners.description}</p>
+        </div>
+        <div ref={gridRef} className="grid grid-cols-2 gap-6 sm:grid-cols-3 md:grid-cols-6">
+          {t.partners.partners.map((partner) => (
+            <div
+              key={partner.name}
+              className="group flex h-24 items-center justify-center rounded-2xl border border-darkBlue/5 bg-lightGray/40 transition hover:border-primary hover:bg-white dark:border-white/10 dark:bg-white/5"
+            >
+              <Image
+                src={partner.logo}
+                alt={`${partner.name} logo`}
+                width={120}
+                height={60}
+                className="h-12 w-auto grayscale transition duration-300 group-hover:grayscale-0"
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/components/plan-section.tsx
+++ b/web/components/plan-section.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useLanguage } from "./language-provider";
+import { gsap } from "../lib/gsap";
+
+export function PlanSection() {
+  const { t, direction } = useLanguage();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const ctx = gsap.context(() => {
+      const steps = gsap.utils.toArray<HTMLElement>("[data-animate=plan-step]");
+      gsap.fromTo(
+        steps,
+        { xPercent: direction === "rtl" ? 40 : -40, opacity: 0 },
+        {
+          xPercent: 0,
+          opacity: 1,
+          duration: 0.7,
+          ease: "power3.out",
+          stagger: 0.2,
+          scrollTrigger: {
+            trigger: containerRef.current,
+            start: "top 80%"
+          }
+        }
+      );
+
+      gsap.fromTo(
+        "[data-animate=plan-line]",
+        { scaleX: 0 },
+        {
+          scaleX: 1,
+          transformOrigin: direction === "rtl" ? "right center" : "left center",
+          duration: 1,
+          ease: "power2.out",
+          scrollTrigger: {
+            trigger: containerRef.current,
+            start: "top 85%"
+          }
+        }
+      );
+    }, containerRef);
+
+    return () => ctx.revert();
+  }, [direction]);
+
+  return (
+    <section id="plan" className="py-24" dir={direction}>
+      <div ref={containerRef} className="mx-auto flex max-w-6xl flex-col gap-16 px-6">
+        <div className="max-w-3xl space-y-4">
+          <h2 className="section-heading">{t.plan.heading}</h2>
+          <p className="section-subheading">{t.plan.description}</p>
+        </div>
+        <div className="relative">
+          <div data-animate="plan-line" className="timeline-line absolute top-1/2 hidden h-1 w-full -translate-y-1/2 lg:block" />
+          <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+            {t.plan.steps.map((step, index) => (
+              <article
+                key={step.title}
+                data-animate="plan-step"
+                className="relative flex h-full flex-col gap-4 rounded-3xl border border-darkBlue/5 bg-white p-8 shadow-card transition dark:border-white/5 dark:bg-white/5"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="timeline-dot" />
+                  <span className="text-sm font-semibold uppercase tracking-widest text-primary">0{index + 1}</span>
+                </div>
+                <h3 className="text-2xl font-semibold text-darkBlue dark:text-white">{step.title}</h3>
+                <p className="text-sm leading-relaxed text-darkBlue/70 dark:text-gray-300">{step.description}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/components/problem-section.tsx
+++ b/web/components/problem-section.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { BookOpen, ShieldCheck, Stethoscope } from "lucide-react";
+import { useEffect, useRef } from "react";
+import { useLanguage } from "./language-provider";
+import { gsap } from "../lib/gsap";
+
+const iconMap = {
+  0: BookOpen,
+  1: Stethoscope,
+  2: ShieldCheck
+} as const;
+
+export function ProblemSection() {
+  const { t, direction } = useLanguage();
+  const cardsRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const ctx = gsap.context(() => {
+      if (!cardsRef.current) return;
+      gsap.fromTo(
+        cardsRef.current.children,
+        { y: 40, opacity: 0 },
+        {
+          y: 0,
+          opacity: 1,
+          duration: 0.6,
+          stagger: 0.2,
+          ease: "power3.out",
+          scrollTrigger: {
+            trigger: cardsRef.current,
+            start: "top 75%"
+          }
+        }
+      );
+    }, cardsRef);
+
+    return () => ctx.revert();
+  }, []);
+
+  return (
+    <section id="problem" className="bg-lightGray/60 py-24 dark:bg-[#0b1328]" dir={direction}>
+      <div className="mx-auto flex max-w-6xl flex-col gap-16 px-6">
+        <div className="max-w-3xl space-y-4">
+          <h2 className="section-heading">{t.problem.heading}</h2>
+          <p className="section-subheading">{t.problem.description}</p>
+        </div>
+        <div ref={cardsRef} className="grid grid-cols-1 gap-8 md:grid-cols-3">
+          {t.problem.cards.map((card, index) => {
+            const Icon = iconMap[index as keyof typeof iconMap];
+            return (
+              <article
+                key={card.title}
+                className="card-surface flex flex-col gap-4"
+                aria-label={card.title}
+              >
+                <span className="inline-flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+                  <Icon className="h-6 w-6" aria-hidden="true" />
+                </span>
+                <h3 className="text-xl font-semibold text-darkBlue dark:text-white">{card.title}</h3>
+                <p className="text-sm text-darkBlue/70 dark:text-gray-300">{card.description}</p>
+              </article>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/components/providers.tsx
+++ b/web/components/providers.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { ThemeProvider } from "./theme-provider";
+import { LanguageProvider } from "./language-provider";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <ThemeProvider>
+      <LanguageProvider>{children}</LanguageProvider>
+    </ThemeProvider>
+  );
+}

--- a/web/components/site-footer.tsx
+++ b/web/components/site-footer.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Link from "next/link";
+import { Facebook, Instagram, Linkedin, Mail, MapPin, Phone } from "lucide-react";
+import { useLanguage } from "./language-provider";
+
+const socials = [
+  { icon: Facebook, href: "https://facebook.com/shifaa", label: "Facebook" },
+  { icon: Instagram, href: "https://instagram.com/shifaa", label: "Instagram" },
+  { icon: Linkedin, href: "https://linkedin.com/company/shifaa", label: "LinkedIn" }
+] as const;
+
+export function SiteFooter() {
+  const { t, direction } = useLanguage();
+
+  return (
+    <footer className="bg-darkBlue text-white" dir={direction}>
+      <div className="mx-auto flex max-w-6xl flex-col gap-16 px-6 py-16">
+        <div className="grid grid-cols-1 gap-12 md:grid-cols-4">
+          <div className="space-y-4 md:col-span-2">
+            <div className="flex items-center gap-3">
+              <span className="inline-flex size-12 items-center justify-center rounded-full bg-primary text-darkBlue text-xl font-bold">
+                S
+              </span>
+              <span className="text-2xl font-semibold">Shifaa</span>
+            </div>
+            <p className="max-w-md text-sm text-white/70">{t.footer.tagline}</p>
+            <div className="flex gap-3">
+              {socials.map((social) => (
+                <Link
+                  key={social.label}
+                  href={social.href}
+                  className="flex size-10 items-center justify-center rounded-full bg-white/10 transition hover:bg-primary hover:text-darkBlue"
+                  aria-label={social.label}
+                >
+                  <social.icon className="h-5 w-5" aria-hidden="true" />
+                </Link>
+              ))}
+            </div>
+          </div>
+          <div className="space-y-3">
+            <h3 className="text-sm font-semibold uppercase tracking-widest text-primary">{t.footer.contact.title}</h3>
+            <p className="flex items-center gap-2 text-sm text-white/80">
+              <Phone className="h-4 w-4" aria-hidden="true" />
+              <a href={`tel:${t.footer.contact.phone}`} className="hover:underline">
+                {t.footer.contact.phone}
+              </a>
+            </p>
+            <p className="flex items-center gap-2 text-sm text-white/80">
+              <Mail className="h-4 w-4" aria-hidden="true" />
+              <a href={`mailto:${t.footer.contact.email}`} className="hover:underline">
+                {t.footer.contact.email}
+              </a>
+            </p>
+            <p className="flex items-start gap-2 text-sm text-white/80">
+              <MapPin className="mt-0.5 h-4 w-4" aria-hidden="true" />
+              <span>{t.footer.contact.address}</span>
+            </p>
+          </div>
+          <div className="grid grid-cols-2 gap-6 text-sm text-white/70 md:grid-cols-1">
+            {t.footer.links.map((group) => (
+              <div key={group.title} className="space-y-3">
+                <h3 className="text-sm font-semibold uppercase tracking-widest text-primary">{group.title}</h3>
+                <ul className="space-y-2">
+                  {group.links.map((link) => (
+                    <li key={link.label}>
+                      <Link href={link.href} className="hover:text-white">
+                        {link.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="border-t border-white/10 pt-6 text-xs text-white/60">{t.footer.rights}</div>
+      </div>
+    </footer>
+  );
+}

--- a/web/components/success-stories.tsx
+++ b/web/components/success-stories.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import Image from "next/image";
+import { ChevronLeft, ChevronRight, Quote } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { motion } from "framer-motion";
+import { useLanguage } from "./language-provider";
+import { cn } from "../lib/utils";
+
+export function SuccessStories() {
+  const { t, direction } = useLanguage();
+  const [active, setActive] = useState(0);
+  const stories = t.success.stories;
+  const sliderRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setActive((prev) => (prev + 1) % stories.length);
+    }, 8000);
+    return () => window.clearInterval(id);
+  }, [stories.length]);
+
+  const goTo = (index: number) => {
+    setActive((index + stories.length) % stories.length);
+  };
+
+  return (
+    <section id="stories" className="bg-white py-24 dark:bg-[#070d1c]" dir={direction}>
+      <div className="mx-auto flex max-w-6xl flex-col gap-12 px-6">
+        <div className="max-w-3xl space-y-4">
+          <h2 className="section-heading">{t.success.heading}</h2>
+          <p className="section-subheading">{t.success.description}</p>
+        </div>
+        <div className="relative">
+          <div className="overflow-hidden rounded-3xl bg-lightGray/60 p-6 dark:bg-white/5" ref={sliderRef}>
+            <motion.div
+              className="flex gap-6"
+              animate={{ x: `${(direction === "rtl" ? active : -active) * 100}%` }}
+              transition={{ type: "spring", stiffness: 120, damping: 25 }}
+            >
+              {stories.map((story) => (
+                <motion.article
+                  key={story.name}
+                  className="group relative flex min-w-full flex-col gap-6 rounded-3xl bg-white p-6 shadow-card dark:bg-white/10"
+                  whileHover={{ y: -6 }}
+                >
+                  <div className="relative aspect-[4/5] overflow-hidden rounded-2xl">
+                    <Image
+                      src={story.image}
+                      alt={story.name}
+                      fill
+                      sizes="(max-width: 768px) 100vw, 50vw"
+                      className="object-cover transition duration-500 group-hover:scale-105"
+                    />
+                  </div>
+                  <div className="space-y-4">
+                    <Quote className="h-8 w-8 text-primary" aria-hidden="true" />
+                    <p className="text-lg font-medium text-darkBlue dark:text-white">{story.quote}</p>
+                    <p className="text-sm font-semibold text-darkBlue/70 dark:text-gray-300">
+                      {story.name} · {story.role}
+                    </p>
+                  </div>
+                </motion.article>
+              ))}
+            </motion.div>
+          </div>
+          <div className="mt-6 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              {stories.map((story, index) => (
+                <button
+                  key={story.name}
+                  type="button"
+                  onClick={() => goTo(index)}
+                  className={cn(
+                    "h-2.5 w-8 rounded-full transition",
+                    active === index ? "bg-primary" : "bg-darkBlue/10 dark:bg-white/20"
+                  )}
+                  aria-label={`Show story ${index + 1}`}
+                />
+              ))}
+            </div>
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={() => goTo(active - 1)}
+                className="flex size-10 items-center justify-center rounded-full border border-darkBlue/10 text-darkBlue transition hover:bg-primary hover:text-darkBlue dark:border-white/10 dark:text-white"
+                aria-label="Previous story"
+              >
+                <ChevronLeft className="h-5 w-5" aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                onClick={() => goTo(active + 1)}
+                className="flex size-10 items-center justify-center rounded-full border border-darkBlue/10 text-darkBlue transition hover:bg-primary hover:text-darkBlue dark:border-white/10 dark:text-white"
+                aria-label="Next story"
+              >
+                <ChevronRight className="h-5 w-5" aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/components/theme-provider.tsx
+++ b/web/components/theme-provider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/web/components/theme-toggle.tsx
+++ b/web/components/theme-toggle.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { Button } from "./ui/button";
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return (
+      <Button variant="ghost" className="rounded-full px-3 py-2" aria-label="Toggle theme" disabled>
+        <Sun className="h-4 w-4" aria-hidden="true" />
+      </Button>
+    );
+  }
+
+  const isDark = theme === "dark";
+
+  return (
+    <Button
+      variant="ghost"
+      className="rounded-full px-3 py-2"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      aria-label={isDark ? "Activate light mode" : "Activate dark mode"}
+    >
+      {isDark ? <Sun className="h-4 w-4" aria-hidden="true" /> : <Moon className="h-4 w-4" aria-hidden="true" />}
+    </Button>
+  );
+}

--- a/web/components/ui/button.tsx
+++ b/web/components/ui/button.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { AnchorHTMLAttributes, ButtonHTMLAttributes } from "react";
+import { cn } from "../../lib/utils";
+
+const MotionButton = motion.create("button");
+const MotionAnchor = motion.create("a");
+
+type NativeButtonProps = ButtonHTMLAttributes<HTMLButtonElement>;
+type NativeAnchorProps = AnchorHTMLAttributes<HTMLAnchorElement>;
+
+export interface ButtonProps extends Partial<NativeButtonProps & NativeAnchorProps> {
+  variant?: "solid" | "outline" | "ghost";
+  href?: string;
+}
+
+export function Button({ className, variant = "solid", children, href, ...rest }: ButtonProps) {
+  const Component: any = href ? MotionAnchor : MotionButton;
+  const componentProps = href
+    ? { href, ...rest }
+    : { type: (rest as NativeButtonProps).type ?? "button", ...rest };
+
+  return (
+    <Component
+      {...componentProps}
+      whileHover={{ scale: 1.02 }}
+      whileTap={{ scale: 0.98 }}
+      className={cn(
+        "inline-flex items-center justify-center gap-2 rounded-full px-6 py-3 text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2",
+        variant === "solid" && "bg-primary text-darkBlue shadow-glow focus-visible:outline-primary/60",
+        variant === "outline" &&
+          "border border-primary text-primary focus-visible:outline-primary/60 dark:text-white dark:border-primary/80",
+        variant === "ghost" && "text-primary hover:bg-primary/10 focus-visible:outline-primary/40",
+        className
+      )}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/web/data/content.ts
+++ b/web/data/content.ts
@@ -1,0 +1,406 @@
+export type Locale = "en" | "ar";
+
+type NavLink = {
+  label: string;
+  href: string;
+};
+
+type ProblemCard = {
+  title: string;
+  description: string;
+};
+
+type PlanStep = {
+  title: string;
+  description: string;
+};
+
+type Story = {
+  name: string;
+  role: string;
+  quote: string;
+  image: string;
+};
+
+type ImpactStat = {
+  label: string;
+  value: number;
+  suffix?: string;
+};
+
+type Partner = {
+  name: string;
+  logo: string;
+};
+
+type FooterLinkGroup = {
+  title: string;
+  links: { label: string; href: string }[];
+};
+
+export type SiteContent = {
+  languageName: string;
+  hero: {
+    preheading: string;
+    heading: string;
+    description: string;
+    primaryCta: string;
+    secondaryCta: string;
+    trustNote: string;
+  };
+  nav: {
+    links: NavLink[];
+    donate: string;
+  };
+  problem: {
+    heading: string;
+    description: string;
+    cards: ProblemCard[];
+  };
+  plan: {
+    heading: string;
+    description: string;
+    steps: PlanStep[];
+  };
+  success: {
+    heading: string;
+    description: string;
+    stories: Story[];
+  };
+  impact: {
+    heading: string;
+    description: string;
+    stats: ImpactStat[];
+  };
+  partners: {
+    heading: string;
+    description: string;
+    partners: Partner[];
+  };
+  cta: {
+    heading: string;
+    description: string;
+    action: string;
+  };
+  footer: {
+    tagline: string;
+    contact: {
+      title: string;
+      phone: string;
+      email: string;
+      address: string;
+    };
+    followUs: string;
+    rights: string;
+    links: FooterLinkGroup[];
+  };
+};
+
+export const content: Record<Locale, SiteContent> = {
+  en: {
+    languageName: "العربية",
+    hero: {
+      preheading: "Relief with dignity",
+      heading: "Hope and healing for every family",
+      description:
+        "Shifaa partners with local communities across the region to deliver emergency relief, rebuild essential services, and empower families with long-term solutions.",
+      primaryCta: "Donate Now",
+      secondaryCta: "Join Us",
+      trustNote: "Registered NGO • Transparent impact reporting"
+    },
+    nav: {
+      links: [
+        { label: "The Need", href: "#problem" },
+        { label: "Our Plan", href: "#plan" },
+        { label: "Stories", href: "#stories" },
+        { label: "Impact", href: "#impact" },
+        { label: "Partners", href: "#partners" }
+      ],
+      donate: "Donate"
+    },
+    problem: {
+      heading: "When crisis strikes, entire futures are at risk",
+      description:
+        "Millions of displaced families face interrupted education, limited healthcare, and heightened vulnerability. We focus on the most urgent barriers to a dignified life.",
+      cards: [
+        {
+          title: "Education",
+          description:
+            "Safe learning spaces, accelerated programs, and psychosocial support for children who have lost years of schooling."
+        },
+        {
+          title: "Health",
+          description:
+            "Mobile clinics, maternal care, and mental health services reaching communities cut off from essential care."
+        },
+        {
+          title: "Protection",
+          description:
+            "Safeguarding women and youth through legal aid, livelihood pathways, and protection services tailored to their reality."
+        }
+      ]
+    },
+    plan: {
+      heading: "A clear path from relief to sustainability",
+      description:
+        "Our three-step approach creates immediate safety, builds resilience, and invests in lasting community systems.",
+      steps: [
+        {
+          title: "Relief",
+          description:
+            "Rapid response teams stabilize families with food, cash assistance, and safe shelter."
+        },
+        {
+          title: "Empowerment",
+          description:
+            "Skills training, education, and health access restore independence and dignity."
+        },
+        {
+          title: "Sustainability",
+          description:
+            "Community-led projects strengthen local systems and create long-term opportunity."
+        }
+      ]
+    },
+    success: {
+      heading: "Stories of resilience",
+      description:
+        "Every donation fuels a real transformation. Meet the people behind the numbers and hear how hope returned to their homes.",
+      stories: [
+        {
+          name: "Amina",
+          role: "Mother & Entrepreneur",
+          quote:
+            "Shifaa's training helped me reopen my tailoring business. Now I provide for my children and mentor other women in our camp.",
+          image: "/images/stories/amina.jpg"
+        },
+        {
+          name: "Omar",
+          role: "Volunteer Medic",
+          quote:
+            "The mobile clinic means our elders receive medicine on time. We feel seen and protected again.",
+          image: "/images/stories/omar.jpg"
+        },
+        {
+          name: "Lina",
+          role: "Student",
+          quote:
+            "After two years without school, I am back in class with friends. I want to become an engineer and rebuild our city.",
+          image: "/images/stories/lina.jpg"
+        }
+      ]
+    },
+    impact: {
+      heading: "Impact at a glance",
+      description:
+        "Transparent metrics updated quarterly so you always know how your support is saving lives.",
+      stats: [
+        { label: "Projects launched", value: 85 },
+        { label: "People reached", value: 220000 },
+        { label: "Active partners", value: 46 }
+      ]
+    },
+    partners: {
+      heading: "Trusted by global partners",
+      description:
+        "Collaboration keeps us accountable and multiplies every gift.",
+      partners: [
+        { name: "UNFPA", logo: "/logos/unfpa.svg" },
+        { name: "GIZ", logo: "/logos/giz.svg" },
+        { name: "UNICEF", logo: "/logos/unicef.svg" },
+        { name: "WFP", logo: "/logos/wfp.svg" },
+        { name: "IRC", logo: "/logos/irc.svg" },
+        { name: "CARE", logo: "/logos/care.svg" }
+      ]
+    },
+    cta: {
+      heading: "Your generosity writes the next success story",
+      description:
+        "Invest in urgent relief and lasting resilience for families overcoming conflict and displacement.",
+      action: "Give Monthly"
+    },
+    footer: {
+      tagline:
+        "Shifaa is a registered NGO dedicated to holistic humanitarian response and community-driven recovery.",
+      contact: {
+        title: "Contact",
+        phone: "+971 4 123 4567",
+        email: "hello@shifaa.org",
+        address: "Building 5, Humanitarian City, Dubai, UAE"
+      },
+      followUs: "Follow us",
+      rights: `© ${new Date().getFullYear()} Shifaa. All rights reserved.`,
+      links: [
+        {
+          title: "Explore",
+          links: [
+            { label: "Our Approach", href: "#plan" },
+            { label: "Programs", href: "#problem" },
+            { label: "Success Stories", href: "#stories" }
+          ]
+        },
+        {
+          title: "Get Involved",
+          links: [
+            { label: "Volunteer", href: "#cta" },
+            { label: "Partner", href: "#partners" },
+            { label: "Donate", href: "#cta" }
+          ]
+        }
+      ]
+    }
+  },
+  ar: {
+    languageName: "English",
+    hero: {
+      preheading: "إغاثة بكرامة",
+      heading: "أمل وشفاء لكل أسرة",
+      description:
+        "تعمل شفاء مع المجتمعات المحلية عبر المنطقة لتقديم الإغاثة العاجلة، وإعادة بناء الخدمات الأساسية، وتمكين العائلات بحلول طويلة الأمد.",
+      primaryCta: "تبرع الآن",
+      secondaryCta: "انضم إلينا",
+      trustNote: "منظمة مسجلة • تقارير أثر شفافة"
+    },
+    nav: {
+      links: [
+        { label: "حجم الحاجة", href: "#problem" },
+        { label: "خطة العمل", href: "#plan" },
+        { label: "قصص نجاح", href: "#stories" },
+        { label: "أثرنا", href: "#impact" },
+        { label: "شركاؤنا", href: "#partners" }
+      ],
+      donate: "تبرع"
+    },
+    problem: {
+      heading: "عندما تضرب الأزمات تُهدد المستقبل بأكمله",
+      description:
+        "الملايين من الأسر النازحة تواجه تعليماً منقطعاً ورعاية صحية محدودة وضعف الحماية. نركز على أخطر العوائق أمام حياة كريمة.",
+      cards: [
+        {
+          title: "التعليم",
+          description:
+            "مساحات تعلم آمنة، وبرامج معجلة، ودعم نفسي اجتماعي للأطفال الذين فقدوا سنوات من الدراسة."
+        },
+        {
+          title: "الصحة",
+          description:
+            "عيادات متنقلة، ورعاية للأمهات، وخدمات للصحة النفسية تصل إلى المجتمعات المحرومة من الرعاية الأساسية."
+        },
+        {
+          title: "الحماية",
+          description:
+            "حماية النساء والشباب من خلال المساعدة القانونية، ومسارات سبل العيش، وخدمات مصممة لاحتياجاتهم."
+        }
+      ]
+    },
+    plan: {
+      heading: "مسار واضح من الإغاثة إلى الاستدامة",
+      description:
+        "نهجنا المكون من ثلاث مراحل يخلق الأمان الفوري، ويعزز القدرة على الصمود، ويستثمر في أنظمة يقودها المجتمع.",
+      steps: [
+        {
+          title: "الإغاثة",
+          description:
+            "تثبت فرق الاستجابة السريعة أوضاع العائلات بالطعام والمساعدات النقدية والمأوى الآمن."
+        },
+        {
+          title: "التمكين",
+          description:
+            "برامج التدريب، والتعليم، والرعاية الصحية تعيد الاستقلال والكرامة."
+        },
+        {
+          title: "الاستدامة",
+          description:
+            "مشاريع يقودها المجتمع تعزز الأنظمة المحلية وتخلق فرصاً طويلة الأمد."
+        }
+      ]
+    },
+    success: {
+      heading: "حكايات صمود",
+      description:
+        "كل تبرع يصنع تحولاً حقيقياً. تعرّف على الأشخاص خلف الأرقام وكيف عاد الأمل إلى بيوتهم.",
+      stories: [
+        {
+          name: "أمينة",
+          role: "أم ورائدة أعمال",
+          quote:
+            "تدريب شفاء ساعدني على إعادة فتح مشروع الخياطة. اليوم أعيل أطفالي وأدرب نساءً أخريات في المخيم.",
+          image: "/images/stories/amina.jpg"
+        },
+        {
+          name: "عمر",
+          role: "مسعف متطوع",
+          quote:
+            "العيادة المتنقلة تعني أن شيوخنا يحصلون على الدواء في الوقت المناسب. شعرنا مجدداً بالأمان والاهتمام.",
+          image: "/images/stories/omar.jpg"
+        },
+        {
+          name: "لينا",
+          role: "طالبة",
+          quote:
+            "بعد عامين بلا دراسة عدت إلى الصف مع أصدقائي. أطمح أن أصبح مهندسة لأعيد بناء مدينتنا.",
+          image: "/images/stories/lina.jpg"
+        }
+      ]
+    },
+    impact: {
+      heading: "أثر ملموس",
+      description:
+        "مؤشرات شفافة يتم تحديثها ربع سنوياً لتعرفوا دائماً كيف يصنع دعمكم الفرق.",
+      stats: [
+        { label: "مشروعاً تم إطلاقه", value: 85 },
+        { label: "مستفيداً", value: 220000 },
+        { label: "شريكاً فعالاً", value: 46 }
+      ]
+    },
+    partners: {
+      heading: "ثقة شركاء عالميين",
+      description:
+        "التعاون يعزز المساءلة ويضاعف أثر كل تبرع.",
+      partners: [
+        { name: "UNFPA", logo: "/logos/unfpa.svg" },
+        { name: "GIZ", logo: "/logos/giz.svg" },
+        { name: "UNICEF", logo: "/logos/unicef.svg" },
+        { name: "WFP", logo: "/logos/wfp.svg" },
+        { name: "IRC", logo: "/logos/irc.svg" },
+        { name: "CARE", logo: "/logos/care.svg" }
+      ]
+    },
+    cta: {
+      heading: "سخاؤكم يصنع قصة النجاح القادمة",
+      description:
+        "ساهموا في إغاثة عاجلة وبناء صمود دائم للأسر المتأثرة بالصراع والنزوح.",
+      action: "تبرع شهرياً"
+    },
+    footer: {
+      tagline:
+        "شفاء منظمة مسجلة متخصصة في الاستجابة الإنسانية الشاملة والتعافي القائم على المجتمع.",
+      contact: {
+        title: "تواصل معنا",
+        phone: "+971 4 123 4567",
+        email: "hello@shifaa.org",
+        address: "المبنى 5، المدينة الإنسانية، دبي، الإمارات"
+      },
+      followUs: "تابعونا",
+      rights: `© ${new Date().getFullYear()} شفاء. جميع الحقوق محفوظة.`,
+      links: [
+        {
+          title: "اكتشف",
+          links: [
+            { label: "منهجيتنا", href: "#plan" },
+            { label: "برامجنا", href: "#problem" },
+            { label: "قصص النجاح", href: "#stories" }
+          ]
+        },
+        {
+          title: "شارك",
+          links: [
+            { label: "تطوع", href: "#cta" },
+            { label: "شراكات", href: "#partners" },
+            { label: "تبرع", href: "#cta" }
+          ]
+        }
+      ]
+    }
+  }
+};

--- a/web/lib/gsap.ts
+++ b/web/lib/gsap.ts
@@ -1,0 +1,8 @@
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+
+if (typeof window !== "undefined" && !gsap.core.globals()["ScrollTrigger"]) {
+  gsap.registerPlugin(ScrollTrigger);
+}
+
+export { gsap, ScrollTrigger };

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -1,0 +1,5 @@
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: (string | undefined | false | null)[]) {
+  return twMerge(inputs.filter(Boolean).join(" "));
+}

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    serverComponentsExternalPackages: ["gsap"]
+  }
+};
+
+export default nextConfig;

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "shifaa-web",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "framer-motion": "^11.0.0",
+    "gsap": "^3.12.5",
+    "lucide-react": "^0.396.0",
+    "next": "^14.2.3",
+    "next-themes": "^0.2.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "tailwind-merge": "^2.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "autoprefixer": "^10.4.18",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.5"
+  }
+}

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/web/public/hero-bg.svg
+++ b/web/public/hero-bg.svg
@@ -1,0 +1,17 @@
+<svg width="1920" height="1080" viewBox="0 0 1920 1080" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="a" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0B1E3F" />
+      <stop offset="100%" stop-color="#00BBFF" />
+    </linearGradient>
+    <radialGradient id="b" cx="30%" cy="20%" r="60%">
+      <stop offset="0%" stop-color="#73DCFF" stop-opacity="0.8" />
+      <stop offset="100%" stop-color="#00BBFF" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1920" height="1080" fill="url(#a)" />
+  <circle cx="400" cy="200" r="320" fill="url(#b)" />
+  <circle cx="1560" cy="220" r="260" fill="url(#b)" opacity="0.45" />
+  <circle cx="960" cy="900" r="420" fill="url(#b)" opacity="0.4" />
+  <path d="M0 760 C320 680 640 820 960 760 C1280 700 1600 840 1920 760 L1920 1080 L0 1080 Z" fill="#ffffff" fill-opacity="0.05" />
+</svg>

--- a/web/public/images/stories/amina.jpg
+++ b/web/public/images/stories/amina.jpg
@@ -1,0 +1,11 @@
+<svg width="600" height="720" viewBox="0 0 600 720" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradA" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00BBFF" />
+      <stop offset="100%" stop-color="#0B1E3F" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="720" rx="40" fill="url(#gradA)" />
+  <circle cx="300" cy="240" r="110" fill="rgba(255,255,255,0.15)" />
+  <rect x="140" y="380" width="320" height="200" rx="120" fill="rgba(255,255,255,0.12)" />
+</svg>

--- a/web/public/images/stories/lina.jpg
+++ b/web/public/images/stories/lina.jpg
@@ -1,0 +1,11 @@
+<svg width="600" height="720" viewBox="0 0 600 720" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradL" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0099DD" />
+      <stop offset="100%" stop-color="#00BBFF" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="720" rx="40" fill="url(#gradL)" />
+  <rect x="180" y="180" width="240" height="240" rx="120" fill="rgba(255,255,255,0.12)" />
+  <rect x="140" y="420" width="320" height="180" rx="90" fill="rgba(255,255,255,0.1)" />
+</svg>

--- a/web/public/images/stories/omar.jpg
+++ b/web/public/images/stories/omar.jpg
@@ -1,0 +1,11 @@
+<svg width="600" height="720" viewBox="0 0 600 720" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gradO" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0B1E3F" />
+      <stop offset="100%" stop-color="#00BBFF" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="720" rx="40" fill="url(#gradO)" />
+  <circle cx="220" cy="220" r="90" fill="rgba(255,255,255,0.1)" />
+  <circle cx="380" cy="420" r="140" fill="rgba(255,255,255,0.08)" />
+</svg>

--- a/web/public/logos/care.svg
+++ b/web/public/logos/care.svg
@@ -1,0 +1,4 @@
+<svg width="140" height="80" viewBox="0 0 140 80" xmlns="http://www.w3.org/2000/svg">
+  <rect width="140" height="80" rx="16" fill="#F2F4F8" />
+  <text x="32" y="50" font-size="34" font-family="'Inter', sans-serif" fill="#FF8A3D" font-weight="700">CARE</text>
+</svg>

--- a/web/public/logos/giz.svg
+++ b/web/public/logos/giz.svg
@@ -1,0 +1,4 @@
+<svg width="140" height="80" viewBox="0 0 140 80" xmlns="http://www.w3.org/2000/svg">
+  <rect width="140" height="80" rx="16" fill="#F2F4F8" />
+  <text x="32" y="50" font-size="36" font-family="'Inter', sans-serif" fill="#B3261E" font-weight="700">GIZ</text>
+</svg>

--- a/web/public/logos/irc.svg
+++ b/web/public/logos/irc.svg
@@ -1,0 +1,4 @@
+<svg width="140" height="80" viewBox="0 0 140 80" xmlns="http://www.w3.org/2000/svg">
+  <rect width="140" height="80" rx="16" fill="#F2F4F8" />
+  <text x="32" y="50" font-size="34" font-family="'Inter', sans-serif" fill="#F47920" font-weight="700">IRC</text>
+</svg>

--- a/web/public/logos/unfpa.svg
+++ b/web/public/logos/unfpa.svg
@@ -1,0 +1,5 @@
+<svg width="140" height="80" viewBox="0 0 140 80" xmlns="http://www.w3.org/2000/svg">
+  <rect width="140" height="80" rx="16" fill="#F2F4F8" />
+  <circle cx="36" cy="40" r="20" fill="#FF9B21" />
+  <text x="70" y="48" font-size="28" font-family="'Inter', sans-serif" fill="#0B1E3F" font-weight="700">UNFPA</text>
+</svg>

--- a/web/public/logos/unicef.svg
+++ b/web/public/logos/unicef.svg
@@ -1,0 +1,4 @@
+<svg width="140" height="80" viewBox="0 0 140 80" xmlns="http://www.w3.org/2000/svg">
+  <rect width="140" height="80" rx="16" fill="#F2F4F8" />
+  <text x="20" y="48" font-size="30" font-family="'Inter', sans-serif" fill="#00AEEF" font-weight="700">UNICEF</text>
+</svg>

--- a/web/public/logos/wfp.svg
+++ b/web/public/logos/wfp.svg
@@ -1,0 +1,4 @@
+<svg width="140" height="80" viewBox="0 0 140 80" xmlns="http://www.w3.org/2000/svg">
+  <rect width="140" height="80" rx="16" fill="#F2F4F8" />
+  <text x="32" y="50" font-size="34" font-family="'Inter', sans-serif" fill="#005EB8" font-weight="700">WFP</text>
+</svg>

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -1,0 +1,36 @@
+import type { Config } from "tailwindcss";
+import { fontFamily } from "tailwindcss/defaultTheme";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./app/**/*.{js,ts,jsx,tsx,mdx}"
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ["var(--font-inter)", ...fontFamily.sans],
+        kufi: ["var(--font-kufi)", ...fontFamily.sans]
+      },
+      colors: {
+        primary: {
+          DEFAULT: "#00bbff",
+          foreground: "#0B1E3F"
+        },
+        darkBlue: "#0B1E3F",
+        lightGray: "#f4f5f7"
+      },
+      backgroundImage: {
+        "hero-pattern": "linear-gradient(135deg, rgba(0,187,255,0.85) 0%, rgba(11,30,63,0.85) 100%)"
+      },
+      boxShadow: {
+        glow: "0 20px 60px rgba(0, 187, 255, 0.25)"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a new `web/` Next.js app with Tailwind, GSAP, Framer Motion, shadcn-style button, and bilingual/theming providers
- implement hero, problem, plan, stories, impact, partners, and donation CTA sections with StoryBrand structure, animations, and accessibility enhancements
- add localized content, placeholder imagery, and partner logos to support Arabic/English copy and hover effects

## Testing
- not run (npm install blocked by registry 403 during setup)


------
https://chatgpt.com/codex/tasks/task_e_68cdaa24201c8325866e07632b707576